### PR TITLE
make hours return as 24h format for more clarity.

### DIFF
--- a/moment.cfc
+++ b/moment.cfc
@@ -462,7 +462,7 @@ component displayname="moment" {
 			case 'hour':
 			case 'h':
 				if (isStartOf) return 'hour';
-				return 'h';
+				return 'H';
 			case 'minutes':
 			case 'minute':
 			case 'n':


### PR DESCRIPTION
changing the hours part to 24 hour otherwise hour() might not return the right answer w/o the am/pm context

for example

```
foo.hour(18);

foo.hour() // 6 because h. So that could be either 6am or 6pm
```