### PR TITLE
chore: remove lucee@7 and adobe@2025 from test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,8 @@ jobs:
       matrix:
         cfml_engine:
           - lucee@6
-          - lucee@7
           - adobe@2021
           - adobe@2023
-          - adobe@2025
       fail-fast: false
     
     steps:


### PR DESCRIPTION
Removed for now due to CI responses:

Version [7] not found for package [lucee].

Error: [ERROR] 2025-10-07T02:55:24Z runwar.context - java.lang.UnsupportedClassVersionError: coldfusion/bootstrap/BootstrapServlet has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0